### PR TITLE
feat : add market order execution logic in engine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   # MySQL
   db:

--- a/src/main/java/org/scoula/backend/order/domain/OrderStatus.java
+++ b/src/main/java/org/scoula/backend/order/domain/OrderStatus.java
@@ -3,5 +3,6 @@ package org.scoula.backend.order.domain;
 public enum OrderStatus {
 	ACTIVE,
 	CANCEL,
-	COMPLETE
+	COMPLETE,
+	MARKET
 }

--- a/src/main/java/org/scoula/backend/order/service/OrderBookService.java
+++ b/src/main/java/org/scoula/backend/order/service/OrderBookService.java
@@ -13,6 +13,7 @@ import org.scoula.backend.order.controller.response.OrderBookResponse;
 import org.scoula.backend.order.controller.response.OrderSnapshotResponse;
 import org.scoula.backend.order.controller.response.OrderSummaryResponse;
 import org.scoula.backend.order.domain.Order;
+import org.scoula.backend.order.domain.OrderStatus;
 import org.scoula.backend.order.domain.Type;
 import org.scoula.backend.order.dto.PriceLevelDto;
 
@@ -35,33 +36,69 @@ public class OrderBookService {
 	// TODO : 채결 완료된 주문 history 저장 필요
 	// TODO : 채결 기준 (-15% - +15%) 적용 필요
 	public void received(final Order order) {
-		if (order.getType() == Type.BUY) {
-			matchBuyOrder(order);
+		// 가격이 0인 경우 시장가 주문으로 처리
+		if (order.getStatus() == OrderStatus.MARKET) {
+			if (order.getType() == Type.BUY) {
+				matchMarketBuyOrder(order);
+			} else {
+				matchMarketSellOrder(order);
+			}
 		} else {
-			matchSellOrder(order);
+			// 기존 지정가 주문 처리
+			if (order.getType() == Type.BUY) {
+				matchBuyOrder(order);
+			} else {
+				matchSellOrder(order);
+			}
 		}
 	}
 
-	private void matchSellOrder(final Order order) {
-		while (order.getRemainingQuantity() > 0) {
+	private void matchSellOrder(final Order sellOrder) {
+		while (sellOrder.getRemainingQuantity() > 0) {
 			log.info("매도 메서드 진입");
 			// 매도가보다 높거나 같은 매수 주문 찾기
 			Map.Entry<BigDecimal, Queue<Order>> bestBid = buyOrders.firstEntry();
 
-			if (bestBid == null || bestBid.getKey().compareTo(order.getPrice()) < 0) {
+			if (bestBid == null || bestBid.getKey().compareTo(sellOrder.getPrice()) < 0) {
 				// 매칭되는 매수 주문이 없으면 주문장에 추가
 				log.info("매도 초기값 할당 조건문 진입");
-				addToOrderBook(sellOrders, order);
+				addToOrderBook(sellOrders, sellOrder);
 				break;
 			}
 
 			// 주문 매칭 처리
-			matchOrders(bestBid.getValue(), order);
+			matchOrders(bestBid.getValue(), sellOrder);
 
 			// 매수 큐가 비었으면 제거
 			if (bestBid.getValue().isEmpty()) {
 				buyOrders.remove(bestBid.getKey());
 			}
+		}
+	}
+
+	private void matchMarketSellOrder(final Order sellOrder) {
+		log.info("시장가 매도 메서드 진입");
+		while (sellOrder.getRemainingQuantity() > 0) {
+
+			// 매도가보다 높거나 같은 매수 주문 찾기
+			Map.Entry<BigDecimal, Queue<Order>> bestBuy = buyOrders.firstEntry();
+
+			if (bestBuy == null) {
+				log.info("남은 시장가 매수 삭제");
+				// 매칭되는 매수 주문이 없으면 남은 주문 그냥 삭제
+				// TODO: 이대로 두어도 되나 ?
+				// handleUnmatchedMarketOrder(buyOrder);
+				return;
+			}
+
+			// 주문 매칭 처리
+			matchOrders(bestBuy.getValue(), sellOrder);
+
+			// 매수 큐가 비었으면 제거
+			if (bestBuy.getValue().isEmpty()) {
+				buyOrders.remove(bestBuy.getKey());
+			}
+			log.info("시장가 매도 체결 완료");
 		}
 	}
 
@@ -73,8 +110,7 @@ public class OrderBookService {
 
 			if (bestAsk == null || bestAsk.getKey().compareTo(buyOrder.getPrice()) > 0) {
 				log.info("매수 초기값 할당 조건문 진입");
-				// 매칭되는 매도 주문이 없으면 주문장에 추가
-				addToOrderBook(buyOrders, buyOrder);
+				addToOrderBook(sellOrders, buyOrder);
 				break;
 			}
 
@@ -88,13 +124,38 @@ public class OrderBookService {
 		}
 	}
 
+	private void matchMarketBuyOrder(final Order buyOrder) {
+		log.info("시장가 매수 메서드 진입");
+		while (buyOrder.getRemainingQuantity() > 0) {
+			// 매수가보다 낮거나 같은 매도 주문 찾기
+			Map.Entry<BigDecimal, Queue<Order>> bestSell = sellOrders.firstEntry();
+
+			if (bestSell == null) {
+				log.info("남은 시장가 매도 삭제");
+				// 매칭되는 매도 주문이 없으면 남은 주문 그냥 삭제
+				// TODO: 이대로 두어도 되나 ?
+				// handleUnmatchedMarketOrder(buyOrder);
+				return;
+			}
+
+			// 주문 매칭 처리
+			matchOrders(bestSell.getValue(), buyOrder);
+
+			// 매수 큐가 비었으면 제거
+			if (bestSell.getValue().isEmpty()) {
+				sellOrders.remove(bestSell.getKey());
+			}
+		}
+		log.info("시장가 매수 체결 완료");
+	}
+
 	private void matchOrders(final Queue<Order> existingOrders, final Order incomingOrder) {
 		while (!existingOrders.isEmpty() && incomingOrder.getRemainingQuantity() > 0) {
 			final Order existingOrder = existingOrders.peek();
 
 			final Integer matchedQuantity = Math.min(
-					incomingOrder.getRemainingQuantity(),
-					existingOrder.getRemainingQuantity()
+				incomingOrder.getRemainingQuantity(),
+				existingOrder.getRemainingQuantity()
 			);
 
 			// 거래 채결 -> OrderHistory
@@ -119,11 +180,20 @@ public class OrderBookService {
 		}
 	}
 
+	private void handleUnmatchedMarketOrder(final Order unmatchedOrder) {
+
+	}
+
 	private void addToOrderBook(final TreeMap<BigDecimal, Queue<Order>> orderBook, final Order order) {
+		if (order.getPrice().compareTo(BigDecimal.ZERO) == 0) {
+			log.warn("시장가 주문은 주문장에 추가할 수 없습니다: {}", order);
+			return;
+		}
+
 		orderBook.computeIfAbsent(
-				order.getPrice(),
-				k -> new PriorityQueue<>(
-						Comparator.comparing(Order::getTimestamp))
+			order.getPrice(),
+			k -> new PriorityQueue<>(
+				Comparator.comparing(Order::getTimestamp))
 		).offer(order);
 	}
 
@@ -135,43 +205,43 @@ public class OrderBookService {
 	// 호가창 생성
 	public OrderBookResponse getBook() {
 		return OrderBookResponse.builder()
-				.companyCode(companyCode)
-				.sellLevels(createAskLevels())
-				.buyLevels(createBidLevels())
-				.build();
+			.companyCode(companyCode)
+			.sellLevels(createAskLevels())
+			.buyLevels(createBidLevels())
+			.build();
 	}
 
 	// 매도 호가창 정보
 	private List<PriceLevelDto> createAskLevels() {
 		return this.sellOrders.entrySet().stream()
-				.limit(5)
-				.sorted(Map.Entry.<BigDecimal, Queue<Order>>comparingByKey().reversed()) // 역순 정렬
-				.map(entry -> new PriceLevelDto(
-						entry.getKey(), calculateTotalQuantity(entry.getValue()), entry.getValue().size())
-				).toList();
+			.limit(5)
+			.sorted(Map.Entry.<BigDecimal, Queue<Order>>comparingByKey().reversed()) // 역순 정렬
+			.map(entry -> new PriceLevelDto(
+				entry.getKey(), calculateTotalQuantity(entry.getValue()), entry.getValue().size())
+			).toList();
 	}
 
 	// 매수 호가창 정보
 	private List<PriceLevelDto> createBidLevels() {
 		return this.buyOrders.entrySet().stream()
-				.limit(5)
-				.map(entry -> new PriceLevelDto(
-						entry.getKey(), calculateTotalQuantity(entry.getValue()), entry.getValue().size())
-				).toList();
+			.limit(5)
+			.map(entry -> new PriceLevelDto(
+				entry.getKey(), calculateTotalQuantity(entry.getValue()), entry.getValue().size())
+			).toList();
 	}
 
 	private Integer calculateTotalQuantity(Queue<Order> orders) {
 		return orders.stream()
-				.mapToInt(Order::getRemainingQuantity)
-				.sum();
+			.mapToInt(Order::getRemainingQuantity)
+			.sum();
 	}
 
 	// 종목별 요약 정보 조회
 	public OrderSummaryResponse getSummary() {
 		return new OrderSummaryResponse(
-				companyCode,
-				getOrderVolumeStats(sellOrders),
-				getOrderVolumeStats(buyOrders)
+			companyCode,
+			getOrderVolumeStats(sellOrders),
+			getOrderVolumeStats(buyOrders)
 		);
 	}
 

--- a/src/main/java/org/scoula/backend/order/service/OrderBookService.java
+++ b/src/main/java/org/scoula/backend/order/service/OrderBookService.java
@@ -16,6 +16,7 @@ import org.scoula.backend.order.domain.Order;
 import org.scoula.backend.order.domain.OrderStatus;
 import org.scoula.backend.order.domain.Type;
 import org.scoula.backend.order.dto.PriceLevelDto;
+import org.scoula.backend.order.service.exception.MatchingException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -76,24 +77,22 @@ public class OrderBookService {
 		}
 	}
 
-	private void matchMarketSellOrder(final Order sellOrder) {
+	private void matchMarketSellOrder(final Order sellOrder) throws MatchingException {
 		log.info("시장가 매도 메서드 진입");
 		while (sellOrder.getRemainingQuantity() > 0) {
 
 			// 매도가보다 높거나 같은 매수 주문 찾기
 			Map.Entry<BigDecimal, Queue<Order>> bestBuy = buyOrders.firstEntry();
-
 			if (bestBuy == null) {
 				log.info("남은 시장가 매수 삭제");
 				// 매칭되는 매수 주문이 없으면 남은 주문 그냥 삭제
 				// TODO: 이대로 두어도 되나 ?
-				// handleUnmatchedMarketOrder(buyOrder);
-				return;
+				throw new MatchingException("주문 체결 불가 : " + sellOrder.getRemainingQuantity());
 			}
+			// handleUnmatchedMarketOrder(buyOrder);
 
 			// 주문 매칭 처리
 			matchOrders(bestBuy.getValue(), sellOrder);
-
 			// 매수 큐가 비었으면 제거
 			if (bestBuy.getValue().isEmpty()) {
 				buyOrders.remove(bestBuy.getKey());

--- a/src/main/java/org/scoula/backend/order/service/exception/MatchingException.java
+++ b/src/main/java/org/scoula/backend/order/service/exception/MatchingException.java
@@ -1,0 +1,14 @@
+package org.scoula.backend.order.service.exception;
+
+public class MatchingException extends Exception {
+	public MatchingException(String message) {
+		super(message);
+	}
+
+	// 예외 던지기 -> tracking 과정을 없애 비용 절감
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+		return this;
+	}
+
+}

--- a/src/main/java/org/scoula/backend/order/service/simulator/SingleOrderSimulator.java
+++ b/src/main/java/org/scoula/backend/order/service/simulator/SingleOrderSimulator.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.scoula.backend.order.domain.Order;
+import org.scoula.backend.order.domain.OrderStatus;
 import org.scoula.backend.order.domain.Type;
 import org.scoula.backend.order.service.OrderService;
 
@@ -34,10 +35,10 @@ public class SingleOrderSimulator {
 	// 시뮬레이션 시작
 	public void startSimulation() {
 		executor.scheduleAtFixedRate(
-				this::generateRandomOrder,
-				0,
-				ORDER_INTERVAL,
-				TimeUnit.MILLISECONDS
+			this::generateRandomOrder,
+			0,
+			ORDER_INTERVAL,
+			TimeUnit.MILLISECONDS
 		);
 	}
 
@@ -56,15 +57,17 @@ public class SingleOrderSimulator {
 		final Type type = random.nextBoolean() ? Type.BUY : Type.SELL;
 		final BigDecimal price = generateRandomPrice();
 		final Integer quantity = generateRandomQuantity();
+		final OrderStatus orderStatus = random.nextBoolean() ? OrderStatus.ACTIVE : OrderStatus.MARKET;
 
 		return Order.builder()
-				.companyCode(CODE)
-				.type(type)
-				.price(price)
-				.totalQuantity(quantity)
-				.remainingQuantity(quantity)
-				.timestamp(LocalDateTime.now())
-				.build();
+			.companyCode(CODE)
+			.type(type)
+			.price(price)
+			.totalQuantity(quantity)
+			.status(orderStatus)
+			.remainingQuantity(quantity)
+			.timestamp(LocalDateTime.now())
+			.build();
 
 	}
 
@@ -81,5 +84,5 @@ public class SingleOrderSimulator {
 	public void stopSimulation() {
 		executor.shutdown();
 	}
-	
+
 }


### PR DESCRIPTION
### 💡 I resolved the following issues:

- market order have priority in all orders. we have to distinguish limit and market order. <br>  market order must be executed all quantity of order. partial or non conclusive order don't exist. 
   

<br><br>

### 💡 Code has been added while handling the issue:

- [feat : add market order execution logic in engine](https://github.com/Stocks-Are-Everywhere/backend-2p/pull/7/commits/ba6e56632417c2a88051c6656c85918a9322ef28)
<br> if market order's remainqantitiy != 0 && map.entry == null -> add return for stopping method. it causes remain order delete.

- [feat : partial execution order delete throws exception](https://github.com/Stocks-Are-Everywhere/backend-2p/pull/7/commits/6cb523ab3d098dc69caef4f490afb1f57189a768)
<br> remained market order throws custom exception

<br><br>

### 💡 Follow-up tasks are needed:

- now, there's no repo layer method. if we connect DB, we need another process for DB, like counting remain order or something else.

<br><br>

### 💡 The following resources might be helpful:

- 

<br><br>

### ✅ Self Checklist

- [x] I am submitting this PR to the correct branch according to our branching strategy. (Not to master/main)

- [x] My commit messages follow the convention.

- [x] The modified code does not generate any compiler/browser warnings/errors.

- [x] The modified code passes all existing tests.

- [x] I have reviewed whether test additions are necessary and added them if needed.

- [x] I have reviewed whether documentation updates are necessary and updated them if needed.
